### PR TITLE
SPM static library support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,10 @@ let package = Package(
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
+            name: "ETPersistentValue-Static",
+            targets: ["ETPersistentValue"]
+        ),
+        .library(
             name: "ETPersistentValue",
             type: .dynamic,
             targets: ["ETPersistentValue"])

--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,15 @@ let package = Package(
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
-            name: "ETPersistentValue-Static",
+            name: "ETPersistentValue",
+            type: .dynamic,
             targets: ["ETPersistentValue"]
         ),
         .library(
-            name: "ETPersistentValue",
-            type: .dynamic,
-            targets: ["ETPersistentValue"])
+            name: "ETPersistentValue-Static",
+            type: .static,
+            targets: ["ETPersistentValue"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.

--- a/Supporting Files/Info.plist
+++ b/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
When using SPM, in some cases there is a need to use the static library. Current projects should not be affected by this change.